### PR TITLE
Handle request errors in WhatsApp tools

### DIFF
--- a/coop-langchain-full/agent/tools/whatsapp.py
+++ b/coop-langchain-full/agent/tools/whatsapp.py
@@ -11,7 +11,11 @@ def send_text(to: str, body: str)->dict:
     url=_endpoint(f"{WA_PHONE_ID}/messages")
     payload={"messaging_product":"whatsapp","to":to,"type":"text","text":{"body": (body or "")[:4096]}}
     with timeit("wa_send_text"):
-        r=requests.post(url, headers={"Authorization": f"Bearer {WA_TOKEN}","Content-Type":"application/json"}, json=payload, timeout=30)
+        try:
+            r=requests.post(url, headers={"Authorization": f"Bearer {WA_TOKEN}","Content-Type":"application/json"}, json=payload, timeout=30)
+        except requests.RequestException as e:
+            log_event("wa.send_text", ok=False, error=str(e))
+            return {"sent": False, "reason": "request_error"}
     ok = r.status_code<300
     log_event("wa.send_text", ok=ok, status=r.status_code)
     return {"sent": ok, "status": r.status_code}
@@ -28,7 +32,29 @@ def send_vagas_list(to: str, vagas: list, title: str="Vagas Abertas", prompt: st
         "interactive":{"type":"list","body":{"text":prompt[:1024]},"action":{"button":"Ver vagas","sections":[{"title":title[:24] or "Vagas","rows":rows}]}}}
     url=_endpoint(f"{WA_PHONE_ID}/messages")
     with timeit("wa_send_list"):
-        r=requests.post(url, headers={"Authorization": f"Bearer {WA_TOKEN}","Content-Type":"application/json"}, json=payload, timeout=30)
+        try:
+            r=requests.post(url, headers={"Authorization": f"Bearer {WA_TOKEN}","Content-Type":"application/json"}, json=payload, timeout=30)
+        except requests.RequestException as e:
+            log_event("wa.send_list", ok=False, error=str(e), rows=len(rows))
+            return {"sent": False, "reason": "request_error"}
     ok = r.status_code<300
     log_event("wa.send_list", ok=ok, status=r.status_code, rows=len(rows))
+    return {"sent": ok, "status": r.status_code}
+
+def send_buttons(to: str, body: str, buttons: list)->dict:
+    if not (WA_TOKEN and WA_PHONE_ID): return {"sent": False, "reason": "missing_whatsapp_env"}
+    acts=[]
+    for i, b in enumerate(buttons[:3]):
+        acts.append({"type":"reply","reply":{"id":f"btn_{i}","title":b[:20] or "..."}})
+    payload={"messaging_product":"whatsapp","to":to,"type":"interactive",
+        "interactive":{"type":"button","body":{"text":body[:1024]},"action":{"buttons":acts}}}
+    url=_endpoint(f"{WA_PHONE_ID}/messages")
+    with timeit("wa_send_buttons"):
+        try:
+            r=requests.post(url, headers={"Authorization": f"Bearer {WA_TOKEN}","Content-Type":"application/json"}, json=payload, timeout=30)
+        except requests.RequestException as e:
+            log_event("wa.send_buttons", ok=False, error=str(e), buttons=len(acts))
+            return {"sent": False, "reason": "request_error"}
+    ok = r.status_code<300
+    log_event("wa.send_buttons", ok=ok, status=r.status_code, buttons=len(acts))
     return {"sent": ok, "status": r.status_code}


### PR DESCRIPTION
## Summary
- catch request exceptions in WhatsApp helpers
- add send_buttons helper and unify error handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7416ca02c832dae8a86cafd6f2a40